### PR TITLE
Add EO + SAR opportunity request POST body examples

### DIFF
--- a/examples/tasking-api/opportunities.json
+++ b/examples/tasking-api/opportunities.json
@@ -1,0 +1,31 @@
+{
+  "geometry": {
+    "type": "Point",
+    "coordinates": [0, 0]
+  },
+  "datetime": "ISO8601/ISO8601",
+  "product_id": "EO",
+  "constraints": {
+    "gsd": [1.0, 10.0],
+    "view:off_nadir": [0, 30],
+    "sat_elevation": [60, 90],
+    "view:sun_elevation": [10, 90],
+    "sat_azimuth": [0, 360],
+    "view:sun_azimuth": [0, 360]
+  }
+}
+
+{
+  "geometry": {
+    "type": "Point",
+    "coordinates": [0, 0]
+  },
+  "datetime": "ISO/ISO",
+  "product_id": "SAR",
+  "constraints": {
+      "ipr": [0.5, 1.0],
+      "grazing": [40.0, 70.0],
+      "azimuth": [-95.0, 95.0],
+      "squint": [-5.0, 5.0]
+  }
+}


### PR DESCRIPTION
- constraints object defined by product endpoint
- datetime field is a ISO8601 Time Interval as defined by https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
- product_id is id field of product objects returned by product endpoint
- constraints when able should map their fields to relevant stac extension fields. example: `view:sun_elevation`