### PR TITLE
Use token from headers in backends

### DIFF
--- a/demo/api/api_types.py
+++ b/demo/api/api_types.py
@@ -2,21 +2,14 @@ from datetime import datetime as Datetime
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from geojson_pydantic.features import Feature, FeatureCollection
-from geojson_pydantic.geometries import (
-    GeometryCollection,
-    LineString,
-    MultiLineString,
-    MultiPoint,
-    MultiPolygon,
-    Point,
-    Polygon,
-)
+from geojson_pydantic.geometries import (GeometryCollection, LineString,
+                                         MultiLineString, MultiPoint,
+                                         MultiPolygon, Point, Polygon)
 from pydantic import BaseModel, Field
 from pydantic.datetime_parse import parse_datetime
 from stac_pydantic.collection import Range
 from stac_pydantic.links import Link
 from stac_pydantic.shared import Provider
-
 
 Geometry = Union[
     Point,
@@ -31,7 +24,6 @@ Geometry = Union[
 
 ProductConstraints = Dict[str, Union[Range, List[Any], Dict[str, Any]]]
 ProductParameters = Dict[str, Union[Range, List[Any], Dict[str, Any]]]
-
 
 
 class Order(BaseModel):

--- a/demo/api/backends/__init__.py
+++ b/demo/api/backends/__init__.py
@@ -1,14 +1,14 @@
-from api.backends.fake_backend import FakeBackend
+from api.backends.base import Backend
 from api.backends.blacksky_backend import BlackskyBackend
+from api.backends.fake_backend import FakeBackend
 from api.backends.planet_backend import PlanetBackend
 from api.backends.sentinel_backend import HistoricalBackend
 from api.backends.umbra_backend import UmbraBackend
 
-
-BACKENDS: dict[str, HistoricalBackend] = {
-    "fake": FakeBackend(),
-    "historical": HistoricalBackend(),
-    "blacksky": BlackskyBackend(),
-    "planet": PlanetBackend(),
-    "umbra": UmbraBackend(),
+BACKENDS: dict[str, Backend] = {
+    "fake": FakeBackend,
+    "historical": HistoricalBackend,
+    "blacksky": BlackskyBackend,
+    "planet": PlanetBackend,
+    "umbra": UmbraBackend,
 }

--- a/demo/api/backends/base.py
+++ b/demo/api/backends/base.py
@@ -1,7 +1,6 @@
-from typing import Protocol, Optional
-import os
+from typing import Protocol
 
-from api.api_types import OpportunityCollection, Product, Search, Order
+from api.api_types import OpportunityCollection, Order, Product, Search
 
 
 # backend protocol class
@@ -27,12 +26,3 @@ class Backend(Protocol):
         token: str,
     ) -> Order:
         return NotImplemented
-
-
-def get_token(backend: str) -> Optional[str]:
-    token_name = f"{backend.upper()}_TOKEN"
-
-    if token_name not in os.environ:
-        # skip endpoint if token not provided
-        return
-    return os.environ[token_name]

--- a/demo/api/backends/blacksky_backend.py
+++ b/demo/api/backends/blacksky_backend.py
@@ -1,69 +1,61 @@
-from datetime import datetime, timedelta
-import os
 import requests
 
 from api.api_types import Opportunity, OpportunityCollection, Search
 
 BLACKSKY_BASE_URL = "https://api.dev.blacksky.com/v1"
 
-def stac_search_to_oppurtunities_request(search_request: Search):
 
+def stac_search_to_oppurtunities_request(search_request: Search):
     """
     :param search_request: STAC search as passed on to find_future_items
     :return: a triple of iw request body, geom and bbox (geom and bbox needed again later to construct STAC answers)
     """
     bs_number, bs_product = "BS-TEST", "Standard"
     if search_request.product_id:
-        bs_number, bs_product = search_request.product_id.split(':')
+        bs_number, bs_product = search_request.product_id.split(":")
 
     return {
-            "item": {
-                "name": "Blacksky_Request",
-                "description": "STAC Sprint",
-                "timeframe": {
-                    "lowerBoundType": "CLOSED",
-                    "lowerEndpoint": search_request.start_date.isoformat(),
-                    "upperBoundType": "CLOSED",
-                    "upperEndpoint": search_request.end_date.isoformat()
-                },
-                "geometry": {
-                    "type": "Point",
-                    "coordinates": [
-                        search_request.geometry.dict()['coordinates'][0],
-                        search_request.geometry.dict()['coordinates'][1],
-                        0
-                    ]
-                },
-                "frequency": "ONCE",
-                "offeringId": "391327b7-f4ee-4e7f-a894-3cffef19cae0",
-                "frequency": "ONCE",
-                "offeringParamValues": {
-                    "priority": "STANDARD",
-                    "sensor": "blacksky"
-                },
-                "externalId": "1234"
+        "item": {
+            "name": "Blacksky_Request",
+            "description": "STAC Sprint",
+            "timeframe": {
+                "lowerBoundType": "CLOSED",
+                "lowerEndpoint": search_request.start_date.isoformat(),
+                "upperBoundType": "CLOSED",
+                "upperEndpoint": search_request.end_date.isoformat(),
             },
-            "includeWeather": True
-        }
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    search_request.geometry.dict()["coordinates"][0],
+                    search_request.geometry.dict()["coordinates"][1],
+                    0,
+                ],
+            },
+            "frequency": "ONCE",
+            "offeringId": "391327b7-f4ee-4e7f-a894-3cffef19cae0",
+            "frequency": "ONCE",
+            "offeringParamValues": {"priority": "STANDARD", "sensor": "blacksky"},
+            "externalId": "1234",
+        },
+        "includeWeather": True,
+    }
 
-def get_oppurtunities(blacksky_request):
 
+def get_oppurtunities(blacksky_request, token):
     headers = {
-        'accept': 'application/json',
-        'Content-Type': 'application/json',
-        'authorization': os.getenv("BLACKSKY_TOKEN")
+        "accept": "application/json",
+        "Content-Type": "application/json",
+        "authorization": token,
     }
 
     r = requests.post(
-        f"{BLACKSKY_BASE_URL}/feasibility/plan",
-        headers=headers,
-        json=blacksky_request
+        f"{BLACKSKY_BASE_URL}/feasibility/plan", headers=headers, json=blacksky_request
     )
-    return r.json()['opportunities']
+    return r.json()["opportunities"]
 
 
 def oppurtunity_to_stac_item(iw):
-
     """
     translates a Planet Imaging Windows into a STAC item
     :param iw: an element from the 'imaging_windows' array of a /imaging_windows/[search_id] response
@@ -72,39 +64,28 @@ def oppurtunity_to_stac_item(iw):
 
     item = Opportunity(
         id=iw["satellite"],
-        geometry={
-                'type': 'Point',
-                     'coordinates': [
-                         iw['longitude'],
-                         iw['latitude'],
-                         0
-                     ]
-        },
+        geometry={"type": "Point", "coordinates": [iw["longitude"], iw["latitude"], 0]},
         properties={
-            'title': '',
-            'datetime': f"{iw['timestamp']}/{iw['timestamp']}",
-            'constraints': {
-                'off_nadir': iw['offNadirAngleDegrees'],
-                'cloud_cover': iw['weatherForecast']['cloudCover']
-            }
-        })
+            "title": "",
+            "datetime": f"{iw['timestamp']}/{iw['timestamp']}",
+            "constraints": {
+                "off_nadir": iw["offNadirAngleDegrees"],
+                "cloud_cover": iw["weatherForecast"]["cloudCover"],
+            },
+        },
+    )
 
     return item
 
+
 class BlackskyBackend:
-
     async def find_opportunities(
-            self,
-            search_request: Search,
-            token: str,
+        self,
+        search_request: Search,
+        token: str,
     ) -> OpportunityCollection:
-
         blacksky_request = stac_search_to_oppurtunities_request(search_request)
-        oppurtunities = get_oppurtunities(blacksky_request)
-        stac_items = [
-            oppurtunity_to_stac_item(iw)
-            for iw
-            in oppurtunities
-        ]
+        oppurtunities = get_oppurtunities(blacksky_request, token)
+        stac_items = [oppurtunity_to_stac_item(iw) for iw in oppurtunities]
 
         return OpportunityCollection(features=stac_items, links=[])

--- a/demo/api/backends/fake_backend.py
+++ b/demo/api/backends/fake_backend.py
@@ -1,6 +1,7 @@
 import pystac
-from api.api_types import Opportunity, OpportunityCollection, Search, Product, Provider
 
+from api.api_types import (Opportunity, OpportunityCollection, Product,
+                           Provider, Search)
 
 STAC_ITEM_URL = (
     "https://raw.githubusercontent.com/stac-utils/pystac/main/"
@@ -8,20 +9,16 @@ STAC_ITEM_URL = (
 )
 
 
-class FakeBackend():
+class FakeBackend:
     async def find_opportunities(
         self,
         search: Search,
         token: str,
-    ) -> Opportunity:
-
+    ) -> OpportunityCollection:
         item = pystac.Item.from_file(STAC_ITEM_URL)
         opportunity = Opportunity(geometry=item.geometry, properties=item.properties)
-        opportunity_collection = OpportunityCollection(
-            features=[opportunity]
-        )
+        opportunity_collection = OpportunityCollection(features=[opportunity])
         return opportunity_collection
-
 
     async def find_products(self, token: str) -> list[Product]:
         # todo: get real list of products
@@ -39,6 +36,6 @@ class FakeBackend():
                 keywords=[],
                 providers=[Provider(name="fake")],
                 constraints={},
-                parameters={}
+                parameters={},
             )
         ]

--- a/demo/api/backends/planet_backend.py
+++ b/demo/api/backends/planet_backend.py
@@ -1,10 +1,10 @@
 import os
-import requests
 import time
 
+import requests
 
-from api.api_types import Search, Opportunity, OpportunityCollection, Product, Provider
-
+from api.api_types import (Opportunity, OpportunityCollection, Product,
+                           Provider, Search)
 
 PLANET_BASE_URL = "https://api.staging.planet-labs.com"
 
@@ -19,7 +19,7 @@ def search_to_imaging_window_request(search_request: Search) -> dict:
     # providing defaults here only temporarily
     pl_number, pl_product = "PL-QA", "Assured Tasking"
     if search_request.product_id:
-        pl_number, pl_product = search_request.product_id.split(':')
+        pl_number, pl_product = search_request.product_id.split(":")
 
     return {
         "datetime": f"{search_request.start_date.isoformat()}/{search_request.end_date.isoformat()}",
@@ -29,23 +29,23 @@ def search_to_imaging_window_request(search_request: Search) -> dict:
     }
 
 
-def get_imaging_windows(planet_request) -> list:
+def get_imaging_windows(planet_request, token: str) -> list:
     headers = {
-        'accept': 'application/json',
-        'Content-Type': 'application/json',
-        'authorization': os.getenv("PLANET_TOKEN")
+        "accept": "application/json",
+        "Content-Type": "application/json",
+        "authorization": token,
     }
 
     r = requests.post(
         f"{PLANET_BASE_URL}/tasking/v2/imaging-windows/search",
         headers=headers,
-        json=planet_request
+        json=planet_request,
     )
 
-    if 'location' not in r.headers:
+    if "location" not in r.headers:
         raise ValueError(
-            "Header 'location' not found: %s, status %s, body %s" % (
-                list(r.headers.keys()), r.status_code, r.text)
+            "Header 'location' not found: %s, status %s, body %s"
+            % (list(r.headers.keys()), r.status_code, r.text)
         )
 
     poll_url = f"{PLANET_BASE_URL}{r.headers['location']}"
@@ -53,12 +53,13 @@ def get_imaging_windows(planet_request) -> list:
 
     while True:
         r = requests.get(poll_url, headers=headers)
-        status = r.json()['status']
+        status = r.json()["status"]
         if status == "DONE":
-            return r.json()['imaging_windows']
-        elif status == 'FAILED':
+            return r.json()["imaging_windows"]
+        elif status == "FAILED":
             raise ValueError(
-                f"Retrieving Imaging Windows failed: {r.json['error_code']} - {r.json['error_message']}'")
+                f"Retrieving Imaging Windows failed: {r.json['error_code']} - {r.json['error_message']}'"
+            )
         # todo async
         time.sleep(1)
 
@@ -74,37 +75,37 @@ def imaging_window_to_opportunity(iw, geom, search_request) -> Opportunity:
         id=iw["id"],
         geometry=geom,
         properties={
-            'title': 'Planet Assured Imaging Window @ ' + iw['start_time'],
-            'datetime': f"{iw['start_time']}/{iw['end_time']}",
-            'product_id': search_request.product_id,
-            'constraints': {
-                'off_nadir': [iw['start_off_nadir'], iw['end_off_nadir']],
-                'cloud_cover': iw['cloud_forecast'][0]['prediction']
-            }
-        })
+            "title": "Planet Assured Imaging Window @ " + iw["start_time"],
+            "datetime": f"{iw['start_time']}/{iw['end_time']}",
+            "product_id": search_request.product_id,
+            "constraints": {
+                "off_nadir": [iw["start_off_nadir"], iw["end_off_nadir"]],
+                "cloud_cover": iw["cloud_forecast"][0]["prediction"],
+            },
+        },
+    )
 
 
 class PlanetBackend:
-
     async def find_opportunities(
         self,
         search_request: Search,
         token: str,
     ) -> OpportunityCollection:
-
         # this assumes we have an Assured product i.e. one which is ordered with respect to a
         # specific imaging window
         # todo: extend this flow to flexible orders
 
         planet_request = search_to_imaging_window_request(search_request)
-        imaging_windows = get_imaging_windows(planet_request)
+        imaging_windows = get_imaging_windows(planet_request, token)
         opportunities = [
-            imaging_window_to_opportunity(iw, planet_request["geometry"], search_request)
-            for iw
-            in imaging_windows
+            imaging_window_to_opportunity(
+                iw, planet_request["geometry"], search_request
+            )
+            for iw in imaging_windows
         ]
         # todo: combine original request and returned imaging window such that the returned
-        #   opportunities are a valid order structure 
+        #   opportunities are a valid order structure
 
         return OpportunityCollection(features=opportunities)
 
@@ -124,6 +125,6 @@ class PlanetBackend:
                 keywords=[],
                 providers=[Provider(name="planet")],
                 constraints={},
-                parameters={}
+                parameters={},
             )
         ]

--- a/demo/api/backends/sentinel_backend.py
+++ b/demo/api/backends/sentinel_backend.py
@@ -3,71 +3,69 @@ import re
 from datetime import timedelta
 from typing import Any, Union
 
-from geojson_pydantic.geometries import Point
 import pystac
-from api.api_types import (Opportunity, OpportunityCollection,
-                           OpportunityProperties, Product, ProductConstraints,
-                           Search, Order, Provider)
+from geojson_pydantic.geometries import Point
 from pystac import Collection, ItemCollection
-
 from pystac_client.client import Client
+
+from api.api_types import (Opportunity, OpportunityCollection,
+                           OpportunityProperties, Order, Product,
+                           ProductConstraints, Provider, Search)
 
 DEFAULT_MAX_ITEMS = 10
 MAX_MAX_ITEMS = 100
 
-LANDSAT_COLLECTION_ID = 'landsat-c2-l2'
-SENTINEL_COLLECTION_ID = 'sentinel-2-l1c'
+LANDSAT_COLLECTION_ID = "landsat-c2-l2"
+SENTINEL_COLLECTION_ID = "sentinel-2-l1c"
 
-PRODUCT_IDS = [
-    LANDSAT_COLLECTION_ID,
-    SENTINEL_COLLECTION_ID
-]
+PRODUCT_IDS = [LANDSAT_COLLECTION_ID, SENTINEL_COLLECTION_ID]
 
 # The api works by pretending the past is the future. It takes a users search request and searches for data in the
 # past. This is the amount of time in the past we search from a request.
-TIME_DELTA = timedelta(days=3*365)
+TIME_DELTA = timedelta(days=3 * 365)
 
 MaybeDate = Union[str, Any]
 
 
 def adjust_date_times(properties: dict[str, Any]) -> OpportunityProperties:
     def adjust_date_time(value: MaybeDate) -> Any:
-        if isinstance(value, str) and re.match(r'\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+.*', value):
+        if isinstance(value, str) and re.match(
+            r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+.*", value
+        ):
             try:
-                date = datetime.datetime.fromisoformat(value.replace('Z','+00:00'))
+                date = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
                 value = f"{(date + TIME_DELTA).isoformat()}/{(date + TIME_DELTA).isoformat()}"
             except Exception as e:
-                print(f'Could not parse {value} as a datetime')
+                print(f"Could not parse {value} as a datetime")
                 raise e
         return value
-    return OpportunityProperties(**{
-        k: adjust_date_time(v)
-        for k, v in properties.items()
-    })
+
+    return OpportunityProperties(
+        **{k: adjust_date_time(v) for k, v in properties.items()}
+    )
 
 
 def stac_item_to_opportunity(item: pystac.Item, product_id: str) -> Opportunity:
-    point_vals = (item.geometry or {}).get('coordinates',[[[0,0]]])[0][0]
+    point_vals = (item.geometry or {}).get("coordinates", [[[0, 0]]])[0][0]
 
     return Opportunity(
         geometry=Point(coordinates=(point_vals[0], point_vals[1])),
-        properties=adjust_date_times({
-            "product_id": product_id,
-            "title": item.id,
-            **item.properties
-        }),
+        properties=adjust_date_times(
+            {"product_id": product_id, "title": item.id, **item.properties}
+        ),
         id=item.id,
     )
+
 
 def stac_collection_to_product(collection: Collection) -> Product:
     constraints: ProductConstraints = {}
     summaries = collection.summaries.to_dict()
 
-    if 'gsd' in summaries:
-        constraints['gsd'] = (min(*summaries['gsd']), max(*summaries['gsd']))
+    if "gsd" in summaries:
+        constraints["gsd"] = (min(*summaries["gsd"]), max(*summaries["gsd"]))
 
     return Product(
-        provider='EarthSearch',
+        provider="EarthSearch",
         id=collection.id,
         title=collection.title or collection.id,
         extends=[],
@@ -81,34 +79,34 @@ def stac_collection_to_product(collection: Collection) -> Product:
         links=[],
         keywords=[],
         providers=[Provider(name="Sentinel")],
-
     )
+
 
 class HistoricalBackend:
     catalog: Client
 
     def __init__(self) -> None:
-        self.catalog = Client.open('https://earth-search.aws.element84.com/v1')  # type: ignore
+        self.catalog = Client.open("https://earth-search.aws.element84.com/v1")  # type: ignore
 
     def _search(self, search) -> ItemCollection:
         max_items = min(search.limit, MAX_MAX_ITEMS)
 
         args: dict[str, Any] = {
-            'collections': [search.product_id],
-            'max_items': max_items,
-            'limit': max_items,
+            "collections": [search.product_id],
+            "max_items": max_items,
+            "limit": max_items,
         }
 
         if search.geometry:
-            args['intersects'] = search.geometry
+            args["intersects"] = search.geometry
 
         if search.start_date and search.end_date:
-            args['datetime'] = [
+            args["datetime"] = [
                 search.start_date - TIME_DELTA,
                 search.end_date - TIME_DELTA,
             ]
         else:
-            raise Exception('A datetime range must be specified')
+            raise Exception("A datetime range must be specified")
 
         search_obj = self.catalog.search(**args)
         return search_obj.item_collection()
@@ -124,18 +122,15 @@ class HistoricalBackend:
             stac_item_to_opportunity(item, product_id=search.product_id)
             for item in item_collection.items
         ]
-        opportunity_collection = OpportunityCollection(
-            features=opportunities
-        )
+        opportunity_collection = OpportunityCollection(features=opportunities)
 
         return opportunity_collection
-
 
     async def find_products(self, token: str) -> list[Product]:
         def safe_get_coll(product_id: str) -> Collection:
             coll = self.catalog.get_collection(product_id)
             if coll is None:
-                raise Exception(f'Could not find collection {product_id}')
+                raise Exception(f"Could not find collection {product_id}")
             return coll
 
         return [
@@ -152,7 +147,9 @@ class HistoricalBackend:
         item_collection = self._search(search)
 
         if len(item_collection.items) == 0:
-            raise ValueError(f"Unable to place an order for this product: '{search.product_id}'")
+            raise ValueError(
+                f"Unable to place an order for this product: '{search.product_id}'"
+            )
 
         best_guess = item_collection.items[0]
         return Order(id=best_guess.id)

--- a/demo/api/backends/umbra_backend.py
+++ b/demo/api/backends/umbra_backend.py
@@ -4,18 +4,13 @@ from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID, uuid4
 
 import requests
-from api.api_types import (
-    Geometry,
-    Opportunity,
-    OpportunityCollection,
-    OpportunityProperties,
-    Product,
-    Search,
-)
-from api.backends.base import Backend
 from pydantic import BaseModel, Field
 from pystac import ProviderRole
 from stac_pydantic.shared import Provider
+
+from api.api_types import (Geometry, Opportunity, OpportunityCollection,
+                           OpportunityProperties, Product, Search)
+from api.backends.base import Backend
 
 UMBRA_BASE_URL = os.getenv("UMBRA_BASE_URL")
 UMBRA_FEASIBILITIES_URL = f"{UMBRA_BASE_URL}/tasking/feasibilities"
@@ -134,9 +129,6 @@ class UmbraBackend(Backend):
         token: str,
     ) -> OpportunityCollection:
         print(f"Umbra - find_opportunities, search: {search}")
-
-        # Grab token from env until we can get it from the header
-        token = os.getenv("UMBRA_TOKEN", "")
 
         if not token:
             raise Exception("Set UMBRA_TOKEN before running the server")


### PR DESCRIPTION
This PR changes the way that the backend gets the token and makes it so they always use the one provided in the headers.

I also ran black and isort on the codebase to standardize it a bit.

Closes #64 