### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ STAPI relies on conformance classes defined in OGC API - Common, as well as defi
 its own Conformance Class for core functionality. STAPI extensions define their
 own Conformance Classes.
 
-For more information on Conformance Classes used in STAPI see the [API Spec](API-SPEC.md).
+For more information on Conformance Classes used in STAPI see the [API Spec](api-spec.md).
 
 ## Example workflows
 


### PR DESCRIPTION
The API Spec link was not pointing to the right file 